### PR TITLE
Fix issue with radios component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+Fix issue with radios component which, when passed a model or form, would treat the value as an array.
+This did not cause an issue for strings as the `include?` method still works for them but if the value was a boolean or a number then an error would be thrown.
+
 ## [0.1.1] - 2023-10-25
 
 Fix some bugs with various helpers and update dependencies

--- a/lib/ccs/components/govuk/field/inputs/radios.rb
+++ b/lib/ccs/components/govuk/field/inputs/radios.rb
@@ -23,7 +23,7 @@ module CCS
 
             public
 
-            # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+            # rubocop:disable Metrics/CyclomaticComplexity
 
             # @param (see CCS::Components::GovUK::Field::Inputs#initialize)
             # @param radio_items [Array<Hash>] an array of options for the radios.
@@ -35,8 +35,8 @@ module CCS
               super(attribute: attribute, **options)
 
               if @options[:model] || @options[:form]
-                values = (@options[:model] || @options[:form].object).send(attribute) || []
-                radio_items.each { |radio_item| radio_item[:checked] = values.include?(radio_item[:value]) }
+                value = (@options[:model] || @options[:form].object).send(attribute)
+                radio_items.each { |radio_item| radio_item[:checked] = value == radio_item[:value] }
               end
 
               radio_item_class = @options[:form] ? Item::Radio::Form : Inputs::Item::Radio::Tag
@@ -44,7 +44,7 @@ module CCS
               @radio_items = radio_items.map { |radio_item| radio_item[:divider] ? Item::Divider.new(divider: radio_item[:divider], type: 'radios') : radio_item_class.new(attribute: attribute, form: @options[:form], context: @context, **radio_item) }
             end
 
-            # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+            # rubocop:enable Metrics/CyclomaticComplexity
 
             # Generates the HTML for the GOV.UK Radios component
             #

--- a/spec/ccs/components/govuk/field/inputs/radios_spec.rb
+++ b/spec/ccs/components/govuk/field/inputs/radios_spec.rb
@@ -543,6 +543,32 @@ RSpec.describe CCS::Components::GovUK::Field::Inputs::Radios do
       end
     end
 
+    context 'when one of the items is checked and the options are booleans' do
+      let(:radio_items) do
+        [
+          {
+            value: true,
+            label: {
+              text: 'Noah'
+            }
+          },
+          {
+            value: false,
+            label: {
+              text: 'N'
+            }
+          }
+        ]
+      end
+
+      before { test_model.ouroboros = true }
+
+      it 'checks the right option' do
+        expect(radio_item_elements.count { |element| element.find('input').checked? }).to eq 1
+        expect(radio_item_elements[0].find('input')).to be_checked
+      end
+    end
+
     context 'when there is a divider' do
       let(:radio_items) do
         [
@@ -838,6 +864,32 @@ RSpec.describe CCS::Components::GovUK::Field::Inputs::Radios do
       it 'checks the right option' do
         expect(radio_item_elements.count { |element| element.find('input').checked? }).to eq 1
         expect(radio_item_elements[2].find('input')).to be_checked
+      end
+    end
+
+    context 'when one of the items is checked and the options are booleans' do
+      let(:radio_items) do
+        [
+          {
+            value: true,
+            label: {
+              text: 'Noah'
+            }
+          },
+          {
+            value: false,
+            label: {
+              text: 'N'
+            }
+          }
+        ]
+      end
+
+      before { test_model.ouroboros = true }
+
+      it 'checks the right option' do
+        expect(radio_item_elements.count { |element| element.find('input').checked? }).to eq 1
+        expect(radio_item_elements[0].find('input')).to be_checked
       end
     end
 


### PR DESCRIPTION
Fix issue with radios component which, when passed a model or form, would treat the value as an array.

This did not cause an issue for strings as the `include?` method still works for them but if the value was a boolean or a number then an error would be thrown.