### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## [0.1.2] - 2023-11-16
 
 Fix issue with radios component which, when passed a model or form, would treat the value as an array.
 This did not cause an issue for strings as the `include?` method still works for them but if the value was a boolean or a number then an error would be thrown.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccs-frontend_helpers (0.1.1)
+    ccs-frontend_helpers (0.1.2)
       rails (>= 6.0)
 
 GEM

--- a/lib/ccs/frontend_helpers/version.rb
+++ b/lib/ccs/frontend_helpers/version.rb
@@ -2,6 +2,6 @@
 
 module CCS
   module FrontendHelpers
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
Fix issue with radios component which, when passed a model or form, would treat the value as an array.
This did not cause an issue for strings as the `include?` method still works for them but if the value was a boolean or a number then an error would be thrown.
