### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## [0.2.0] - 2024-03-13
 
 ### 💥 Breaking changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccs-frontend_helpers (0.1.2)
+    ccs-frontend_helpers (0.2.0)
       rails (>= 6.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following table shows the version of CCS Frontend Helpers that you should us
 
 | CCS Frontend Helpers Version | Target GOV.UK Frontend Version |
 | ----------------------------- | ------------------------------ |
+| [0.2.0](https://github.com/tim-s-ccs/ccs-frontend_helpers/releases/tag/v0.2.0) | [5.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.2.0) |
 | [0.1.2](https://github.com/tim-s-ccs/ccs-frontend_helpers/releases/tag/v0.1.2) | [4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) |
 
 Any other versions of GOV.UK Frontend not shown above _may_ still be compatible, but have not been specifically tested and verified.

--- a/lib/ccs/frontend_helpers/version.rb
+++ b/lib/ccs/frontend_helpers/version.rb
@@ -2,6 +2,6 @@
 
 module CCS
   module FrontendHelpers
-    VERSION = '0.1.2'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
### 💥 Breaking changes

Update components to be compatible with GOV.UK Frontend v5.2

For pagination, the option to enable ellipsis is now:
```ruby
{
  ellipsis: true
}
```
instead of:
```ruby
{
  type: :ellipsis
}
```

### 🏠 Internal changes

Add tests for GOV.UK Frontend fixtures

### 🆕 New features

The following GOV.UK helpers have been added:

- Exit this page
- Task list
